### PR TITLE
GithHub actions now run on all supported PHP versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,5 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: php-actions/composer@v5
+      - uses: php-actions/composer@v6
+        with:
+          php_version: "8.0"
       - uses: NWBY/pest-action@v1.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,12 @@ on: ['push']
 jobs:
   pest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.4', '8.0']
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: php-actions/composer@v6
         with:
-          php_version: "8.0"
+          php_version: ${{ matrix.php-versions }}
       - uses: NWBY/pest-action@v1.2.0


### PR DESCRIPTION
<!-- Indicate the issue resolved by this pull request. -->
Resolves #46

## Description
<!-- Describe how and why changes were made. -->
This fixes the GitHub action by specifying the PHP version for the composer step. I also tackled #46 as part of this by using a matrix for the PHP version. Currently the tests will run on PHP 7.4 and 8.0, when 8.1 support is released it will need to be added to the matrix as well. 

## Visuals
<!-- Include screenshots or video to better communicate the changes. -->

## Testing Instructions
<!-- Help others test the pull request as efficiently as possible. -->

1. Push a commit to branch.
2. You should see two checks running for Pest, one for 7.4 and one for 8.0

## Related Documentation
<!-- List any existing documentation links affected by this pull request. -->

## Pre-review Checklist
<!-- Complete these tasks prior to a review. -->

- [x] Acceptance criteria have been satisfied and marked in the related issue.
- [x] Feature/Unit tests have been added and/or updated (where appropriate).
- [x] Self-review of code changes has been completed.
- [ ] Self-review of UI and UX changes has been completed, including dark mode and mobile responsiveness.
    - [ ] UI matches the provided Figma mockups (when available).
- [x] Modified and surrounding functionality has been tested. Considerations have been made for both new and existing servers and sites.